### PR TITLE
Override default scope separator from comma to space

### DIFF
--- a/src/Provider/EveOnline.php
+++ b/src/Provider/EveOnline.php
@@ -67,6 +67,17 @@ class EveOnline extends AbstractProvider
     {
         return [];
     }
+    
+    /**
+     * Returns the string that should be used to separate scopes when building
+     * the URL for requesting an access token.
+     *
+     * @return string Scope separator
+     */
+    protected function getScopeSeparator()
+    {
+        return ' ';
+    }
 
     /**
      * Check a provider response for errors.


### PR DESCRIPTION
Hi @killmails 

As per the documentation at https://eveonline-third-party-documentation.readthedocs.io/en/latest/sso/authentication.html#redirect-to-the-sso , scopes should be space-delimited.

The default in the league package is for the scopes to be comma-separated cuasing the EVE Login Service to give an *invalid scope* error. This PR overrides the `getScopeSeparator()` function to fix this